### PR TITLE
fixed observer after google broke it + updated regex for new meet urls

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -101,7 +101,7 @@ function messageHandler(request, sender, sendResponse) {
     return
   } else if (request.action === 'update') {  
     if (sender.tab) {
-      let meetId = sender.url.match(/https?:\/\/meet\.google\.com\/(\w+-\w+-\w+)/)
+      let meetId = sender.url.match(/https?:\/\/meet\.google\.com\/(?:_meet\/)?(\w+-\w+-\w+)(?:\?.*$)?/)
       meetId = meetId ? meetId[1] : 'none'
       const meeting = {
         meetId: meetId,

--- a/lib/content.js
+++ b/lib/content.js
@@ -48,7 +48,11 @@ function setMuteStatus(target) {
 function pageChanged(mutations, observer) {
   mutations.forEach( (m) => {
     if (m.type == 'attributes') {
-      if (m.target.matches('div[data-tooltip*="microphone"]') || m.target.matches('div[aria-label~="Microphone"]')) {
+      if (
+        m.target.matches('div[data-tooltip*="microphone"]') 
+        || m.target.matches('div[aria-label*="microphone"]')
+        || m.target.matches('button[aria-label*="microphone"]')
+      )  {
         setMuteStatus(m.target)
       }
     }


### PR DESCRIPTION
This PR fixes a breaking change Google made to the meet interface and a significant, yet non-breaking change made to the URL scheme. 

1. CRITICAL: The observer that finds the mute button broke when it was switched from a `div` to a `button`. 
2. IMPORTANT: URL scheme was changed when creating an "instant meeting." Instead of just dropping you into `meet.google.com/<meeting-id>`, it first sent you to `meet.google.com/_meet/<meeting-id>?<additional-params>`. The original regex was not written to account for this and thus could not capture the meeting ID. It has been updated to account for both cases as if you are joining a meeting rather than creating one, you still get the original URL scheme.   